### PR TITLE
ci: Split CodeQL into separate parallel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ on:
   pull_request:
 
 jobs:
-  build-and-analyse:
-    name: Build, test, and analyse
+  build-and-test:
+    name: Build and test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
@@ -27,12 +27,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
-        with:
-          languages: kotlin
-          config-file: ./.github/codeql-config.yml
 
       - name: Build all targets
         run: ./gradlew build --no-daemon --stacktrace
@@ -75,6 +69,37 @@ jobs:
           sarif_file: build/reports/detekt/detekt.sarif
           category: detekt
 
+  security-scan:
+    name: CodeQL security analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: kotlin
+          config-file: ./.github/codeql-config.yml
+
+      - name: Build without cache for CodeQL
+        run: ./gradlew build --no-daemon --no-build-cache --stacktrace
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
@@ -83,7 +108,7 @@ jobs:
   android-test:
     name: Android Instrumentation Tests
     runs-on: ubuntu-latest
-    needs: build-and-analyse
+    needs: build-and-test
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      actions: read
 
     steps:
       - name: Checkout code
@@ -72,11 +71,10 @@ jobs:
   security-scan:
     name: CodeQL security analysis
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write
-      actions: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

CodeQL fails with "could not process any code" on PRs that don't modify dependencies (PRs #12, #14, #15).

**Root cause**: Gradle's build cache serves compilation results as `FROM-CACHE`, preventing CodeQL from tracing any actual compilation. Dependabot PRs pass because changing dependencies invalidates the cache.

## Solution Trade-off

This is a workaround for CodeQL's inability to work with Gradle's build cache. We split CI into two parallel jobs:

1. **build-and-test**: Fast feedback with cache enabled.
2. **security-scan**: CodeQL analysis with `--no-build-cache` flag.

**Trade-off**: We build twice to get both fast feedback and working CodeQL.