### PR TITLE
ci: Use OAuth token for Claude Code authentication

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -28,6 +28,6 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1.0.16
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --max-turns 10

--- a/.github/workflows/claude-pr.yml
+++ b/.github/workflows/claude-pr.yml
@@ -42,6 +42,6 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1.0.16
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --max-turns 10


### PR DESCRIPTION
Switch from anthropic_api_key to claude_code_oauth_token in both Claude Code workflows to fix authentication failures.