### PR TITLE
chore: Add read-only GH/Git Bash commands to Claude Code's allowlist

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,9 @@
       "Bash(gh run view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
-      "Bash(gh repo view:*)"
+      "Bash(gh repo view:*)",
+      "Bash(gh issue view:*)",
+      "Bash(git diff:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,13 +4,13 @@
       "WebSearch",
       "Bash(./gradlew:*)",
       "Bash(git log:*)",
+      "Bash(git diff:*)",
       "Bash(gh run list:*)",
       "Bash(gh run view:*)",
       "Bash(gh pr list:*)",
       "Bash(gh pr view:*)",
       "Bash(gh repo view:*)",
-      "Bash(gh issue view:*)",
-      "Bash(git diff:*)"
+      "Bash(gh issue view:*)"
     ],
     "deny": [],
     "ask": []


### PR DESCRIPTION
Adds two read-only commands to the Claude Code allowlist:

- `Bash(gh issue view:*)` - allows viewing GitHub issues
- `Bash(git diff:*)` - allows viewing git diffs

These commands are read-only operations that help Claude Code better understand the codebase and GitHub context without requiring user approval.

Fixes #29

---
Generated with [Claude Code](https://claude.ai/code)