### PR TITLE
ci: Simplify Claude workflow by removing issue assignment handling

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -3,14 +3,10 @@ name: Claude Code (Issues)
 on:
   issue_comment:
     types: [created]
-  issues:
-    types: [opened, assigned]
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'issues' && github.event.assignee.login == 'claude') ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    if: contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Remove unnecessary issue assignment trigger and condition from Claude workflow. Claude can only be triggered by @claude mentions in comments, not by issue assignment.

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)