### PR TITLE
ci: Increase Claude workflow timeout and max turns

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -12,7 +12,7 @@ jobs:
       (github.event_name == 'issues' && github.event.assignee.login == 'claude') ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write
@@ -30,4 +30,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --max-turns 10
+            --max-turns 30

--- a/.github/workflows/claude-pr.yml
+++ b/.github/workflows/claude-pr.yml
@@ -26,7 +26,7 @@ jobs:
         }}
       cancel-in-progress: ${{ github.event_name == 'pull_request_review_comment' }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write
@@ -44,4 +44,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --max-turns 10
+            --max-turns 30


### PR DESCRIPTION
- Increase timeout-minutes from 10 to 20 minutes
- Increase --max-turns from 10 to 30 turns

This addresses issue where Claude Code consistently hits the max-turns limit before completing tasks, causing the workflow to succeed but leave work incomplete (no commits, no PRs, pending todos). For example: https://github.com/gnarea/segnale/issues/16