### PR TITLE
ci: Add missing permission to auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.actor == 'dependabot[bot]' && github.event.action == 'opened' }}
     permissions:
+      contents: "write"
       pull-requests: "write"
     steps:
       - name: Auto-merge PR


### PR DESCRIPTION
Fixes runs like https://github.com/gnarea/segnale/actions/runs/19043375599/job/54385667305?pr=32