### PR TITLE
ci: Fix failing CI/CD pipeline test

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: "write"
     steps:
       - name: Auto-merge PR
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The repository is configured to only allow squash commits, but the Dependabot auto-merge workflow was using `--merge` flag. This caused the `gh pr merge --auto` command to fail with exit code 1.

Changed from `--merge` to `--squash` to align with repository settings.

Fixes https://github.com/gnarea/segnale/actions/runs/19240029706/job/55000121204