### PR TITLE
chore(Renovate): Remove invalid npm-specific config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,15 +10,9 @@
   "platformAutomerge": true,
   "packageRules": [
     {
-      "description": "Production dependencies use fix(deps) prefix",
-      "matchDepTypes": ["dependencies"],
+      "description": "Gradle dependencies use fix(deps) prefix",
+      "matchManagers": ["gradle", "gradle-wrapper"],
       "semanticCommitType": "fix",
-      "semanticCommitScope": "deps"
-    },
-    {
-      "description": "Development dependencies use chore(deps) prefix",
-      "matchDepTypes": ["devDependencies"],
-      "semanticCommitType": "chore",
       "semanticCommitScope": "deps"
     },
     {


### PR DESCRIPTION
The configuration was using matchDepTypes with 'dependencies' and
'devDependencies', which are npm/JavaScript terms. This Gradle/Kotlin
project doesn't have these dependency types, causing Renovate
validation to fail.

Simplified the configuration to use matchManagers instead, which
properly targets Gradle and GitHub Actions dependencies.

Fixes #50

Co-authored-by: Gus Narea <gnarea@users.noreply.github.com>