### PR TITLE
chore(Renovate): Remove conflicting ignoreUnstable option

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,6 @@
     {
       "description": "Auto-merge patch and minor updates",
       "matchUpdateTypes": ["patch", "minor"],
-      "ignoreUnstable": true,
       "automerge": true
     }
   ]


### PR DESCRIPTION
Remove `ignoreUnstable` from the auto-merge package rule as Renovate does not allow combining `matchUpdateTypes` with `ignoreUnstable` in the same rule.

Fixes #52